### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to Duplexity
+
+Thank you for your interest in contributing to Duplexity! We hope that this guide will help to make contributing an easy process, but please do get in touch if you have any questions or need guidance. 
+
+## How to Contribute
+
+We welcome contributions of new metrics, be it something you have developed or an existing method you think is missing from the package. We recommend reading through the documentation thoroughly to decide where in the package your contribution best fits. If you are unsure which module to add your method to, please get in touch and we'd be happy to discuss! 
+
+Before getting started with the below guide, we recommend [creating an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue) or commenting on an existing issue to let others know you are going to work on this. 
+
+### 1. Fork Duplexity
+Forking the Duplexity repo will make a copy of the repository in your own Github account. Any changes you make in this forked repository won't affect anyone else's code. We still recommend that you use branches to develop on your own fork. Be sure to [keep your fork up to date](https://help.github.com/articles/syncing-a-fork) with the main Duplexity repository to avoid merge conflicts as best as possible. 
+
+To learn more about forking a repository, have a look [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo).
+
+### 2. Add your contribution(s)
+[Clone the forked repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo#cloning-your-forked-repository) locally to your computer. We recommend using focused branches when making edits, committing your work often and writing detailed commit messages. [This blog](https://chris.beams.io/posts/git-commit/) details what a good commit message looks like and why it is important. 
+
+Please see below for requirements your contribution must follow to be added to the Duplexity main repository.
+
+### 3. Submit a pull request
+When you are ready for your changes to be merged into the main Duplexity repo, please [create a pull request from your fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork) into the main repository. Please include the following details in your pull request: 
+- Describe the addition or fix that you've made, referencing any related issues.
+- Any notes to the reviewer
+
+A member of the Duplexity team will then review your changes to confirm that they can be merged into the main repository. This may include some discussion back and forth, so please keep an eye on your Github notifications! 
+
+## Contribution Requirements
+Contributions are not just limited to writing code, and may include edits to documentation. More guidance on documentation contributions is yet to come, but some initial guidance on contributing code is given below. 
+
+### Contributing code
+We ask that any code contributions, particularly when adding new metrics, include the following in the pull request:
+- Code addition
+- Documentation update
+- Tests
+
+These additions should also be described in the pull requests and commit messages. More information will be added to this guide to help in writing documentation and tests soon. In the meantime, please contact us if you need any help.
+
+## Acknowledgements
+This contributing guide was made following recommendations from [The Turing Way](https://github.com/the-turing-way/the-turing-way/blob/main/CONTRIBUTING.md?plain=1#L411). 


### PR DESCRIPTION
Creating an initial contributing guide for external users to Duplexity. This needs further expansion, including how to contribute to documentation, testing methodologies, use of PEP8 etc, but this is still to be added.

@lexixu19, if you are happy with this initial contributing guide can you please merge the pull request and add this file to the docs. Thanks!

Ref: #6